### PR TITLE
Revert workaround & rename DECL naming

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,6 @@ project(laser_geometry)
 find_package(catkin REQUIRED
     COMPONENTS
         angles
-        cmake_modules
         roscpp
         sensor_msgs
         tf
@@ -13,30 +12,20 @@ find_package(catkin REQUIRED
 
 find_package(Boost REQUIRED COMPONENTS system thread)
 
-find_package(Eigen3 QUIET)
-if(NOT EIGEN3_FOUND)
-  # Fallback to cmake_modules
-  find_package(cmake_modules REQUIRED)
-  find_package(Eigen REQUIRED)
-  set(EIGEN3_INCLUDE_DIRS ${EIGEN_INCLUDE_DIRS})
-  set(EIGEN3_LIBRARIES ${EIGEN_LIBRARIES})  # Not strictly necessary as Eigen is head only
-  # Possibly map additional variables to the EIGEN3_ prefix.
-else()
-  set(EIGEN3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
-endif()
+find_package(Eigen3 REQUIRED)
 
 catkin_python_setup()
 
 catkin_package(
   INCLUDE_DIRS include ${EIGEN3_INCLUDE_DIRS}
   LIBRARIES laser_geometry
-  DEPENDS Boost Eigen3
+  DEPENDS Boost EIGEN3
 )
 
 include_directories(include
     ${catkin_INCLUDE_DIRS}
     ${Boost_INCLUDE_DIRS}
-    ${EIGEN3_INCLUDE_DIRS}
+    ${EIGEN3_INCLUDE_DIR}
 )
 
 add_library(laser_geometry src/laser_geometry.cpp)
@@ -50,9 +39,7 @@ if(CATKIN_ENABLE_TESTING)
 endif()
 
 install(TARGETS laser_geometry
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
+  DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 install(DIRECTORY include/laser_geometry/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
   FILES_MATCHING PATTERN "*.h")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ find_package(Eigen3 REQUIRED)
 catkin_python_setup()
 
 catkin_package(
-  INCLUDE_DIRS include ${EIGEN3_INCLUDE_DIRS}
+  INCLUDE_DIRS include
   LIBRARIES laser_geometry
   DEPENDS Boost EIGEN3
 )

--- a/include/laser_geometry/laser_geometry.h
+++ b/include/laser_geometry/laser_geometry.h
@@ -53,12 +53,12 @@
 
 #ifdef ROS_BUILD_SHARED_LIBS // ros is being built around shared libraries
   #ifdef laser_geometry_EXPORTS // we are building a shared lib/dll
-    #define LZR_GEO_DECL ROS_HELPER_EXPORT
+    #define LASER_GEOMETRY_DECL ROS_HELPER_EXPORT
   #else // we are using shared lib/dll
-    #define LZR_GEO_DECL ROS_HELPER_IMPORT
+    #define LASER_GEOMETRY_DECL ROS_HELPER_IMPORT
   #endif
 #else // ros is being built around static libraries
-  #define LZR_GEO_DECL
+  #define LASER_GEOMETRY_DECL
 #endif
 
 namespace laser_geometry
@@ -110,7 +110,7 @@ namespace laser_geometry
    * - channel_option::Distance - Create a channel named "distances" containing the distance from the laser to each point
    * - channel_option::Timestamp - Create a channel named "stamps" containing the specific timestamp at which each point was measured
    */
-  class LZR_GEO_DECL LaserProjection
+  class LASER_GEOMETRY_DECL LaserProjection
     {
 
     public:


### PR DESCRIPTION
* Revert CMakeList.txt workaround for catkin linkage issue.
* Rename DECL to use full name which looks more like ROS naming style.

Compared to upstream repo:
https://github.com/ros-perception/laser_geometry/compare/indigo-devel...seanyen-msft:init_windows?expand=1